### PR TITLE
Adding support for GIST Indexes

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -267,6 +267,7 @@ func diffCreateIndexes(ops []operations.Operation, d1, d2 *schema.Database) []op
 						SchemaName: schemaName,
 						TableName:  tableName,
 						IndexName:  name,
+						Type:       i2.Type,
 						Columns:    i2.Columns,
 					})
 				}

--- a/operations/create_index.go
+++ b/operations/create_index.go
@@ -11,11 +11,12 @@ type CreateIndex struct {
 	SchemaName string
 	TableName  string
 	IndexName  string
+	Type       schema.IndexType
 	Columns    []string
 }
 
 func (o CreateIndex) GetSQL() string {
-	return fmt.Sprintf("CREATE INDEX CONCURRENTLY \"%s\" ON %s (%s)", o.IndexName, sqlName(o.SchemaName, o.TableName), columnList(o.Columns))
+	return fmt.Sprintf("CREATE INDEX CONCURRENTLY \"%s\" ON %s %s (%s)", o.IndexName, sqlName(o.SchemaName, o.TableName), indexType(o.Type), columnList(o.Columns))
 }
 
 func (o CreateIndex) Dump(w io.Writer) {
@@ -23,6 +24,7 @@ func (o CreateIndex) Dump(w io.Writer) {
 	fmt.Fprint(w, "SchemaName: "+esc(o.SchemaName)+",\n")
 	fmt.Fprint(w, "TableName: "+esc(o.TableName)+",\n")
 	fmt.Fprint(w, "IndexName: "+esc(o.IndexName)+",\n")
+	_, _ = fmt.Fprintf(w, "Type: %s,\n", o.Type)
 	fmt.Fprint(w, "Columns: []string{"+columnList(o.Columns)+"},\n")
 	fmt.Fprint(w, "}")
 }

--- a/operations/util.go
+++ b/operations/util.go
@@ -3,6 +3,7 @@ package operations
 import (
 	"bytes"
 	"fmt"
+	"github.com/sqlbunny/sqlschema/schema"
 )
 
 func sqlName(schema, name string) string {
@@ -34,4 +35,15 @@ func columnList(columns []string) string {
 		buf.WriteString("\"")
 	}
 	return buf.String()
+}
+
+func indexType(t schema.IndexType) string {
+	switch t {
+	case schema.DefaultIndex:
+		return ""
+	case schema.GISTIndex:
+		return "USING GIST"
+	default:
+		return ""
+	}
 }

--- a/schema/keys.go
+++ b/schema/keys.go
@@ -5,9 +5,26 @@ type PrimaryKey struct {
 	Columns []string
 }
 
+type IndexType int
+
+func (t IndexType) String() string {
+	switch t {
+	case DefaultIndex:
+		return "default"
+	case GISTIndex:
+		return "GIST"
+	default:
+		return "default"
+	}
+}
+
+const DefaultIndex = 0
+const GISTIndex = 1
+
 // Index represents an index in a database
 type Index struct {
 	Columns []string
+	Type    IndexType
 }
 
 // Unique represents a unique constraint in a database


### PR DESCRIPTION
This proposal adds support to sqlschema for PostgreSQL GIST indexes.  GIST indexes are very useful to improve postgis searches. https://postgis.net/docs/using_postgis_dbmanagement.html#idm2461 

I first started doing modifications in sqlbunny until I realizaded that the real SQL code is generated by this package. My idea is to do another PR in bunny that could use GIST indexes.

I hope changes are correct. I also understand that this change could be controversial because it adds code that is strongly tied to postgres and postgis and/or full text search usage, so no problem if you deny this PR.
